### PR TITLE
Basic meetup generator tool that loads data and generate meeetup group files

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -112,8 +112,6 @@ func exec(cfg *Config) (map[string][]byte, error) {
 		result[path] = b
 	}
 
-	fmt.Println(result)
-
 	return result, nil
 }
 

--- a/generator/templates.go
+++ b/generator/templates.go
@@ -1,0 +1,11 @@
+package main
+
+import "text/template"
+
+var (
+	readmeTmpl = template.Must(template.New("").Parse(readmeTmplStr))
+)
+
+const (
+	readmeTmplStr = `# {{ .MeetupName }} Meetup`
+)

--- a/generator/templates.go
+++ b/generator/templates.go
@@ -7,5 +7,10 @@ var (
 )
 
 const (
-	readmeTmplStr = `# {{ .MeetupName }} Meetup`
+	readmeTmplStr = `# Meetups organized by {{ .MeetupName }}
+	
+	## Organizers
+	{{ range .Organizers }}- {{ . }}
+	{{ end }}
+	`
 )

--- a/generator/templates.go
+++ b/generator/templates.go
@@ -8,9 +8,8 @@ var (
 
 const (
 	readmeTmplStr = `# Meetups organized by {{ .MeetupName }}
-	
-	## Organizers
-	{{ range .Organizers }}- {{ . }}
-	{{ end }}
-	`
+
+## Organizers
+{{ range .Organizers }}- {{ . }}
+{{ end }}`
 )

--- a/generator/types.go
+++ b/generator/types.go
@@ -13,7 +13,7 @@ var (
 )
 
 type Speaker struct {
-	ID       CompanyID `json:"id"`
+	ID       SpeakerID `json:"id"`
 	Name     string    `json:"name"`
 	Title    string    `json:"title"`
 	Company  string    `json:"company"`
@@ -30,8 +30,9 @@ type Company struct {
 }
 
 type MeetupGroup struct {
-	MeetupID string            `json:"meetupID"`
-	Meetups  map[string]Meetup `json:"meetups"`
+	MeetupID   string            `json:"meetupID"`
+	Organizers []string          `json:"organizers"`
+	Meetups    map[string]Meetup `json:"meetups"`
 }
 
 type Meetup struct {
@@ -46,10 +47,11 @@ type MeetupSponsor struct {
 }
 
 type Presentation struct {
-	Title     string    `json:"title"`
-	Slides    string    `json:"slides"`
-	Recording string    `json:"recording,omitempty"`
-	Speakers  []Speaker `json:"speakers"`
+	Duration  string   `json:"duration"`
+	Title     string   `json:"title"`
+	Slides    string   `json:"slides"`
+	Recording string   `json:"recording,omitempty"`
+	Speakers  []string `json:"speakers"`
 }
 
 type Config struct {

--- a/generator/types.go
+++ b/generator/types.go
@@ -30,7 +30,9 @@ type Company struct {
 }
 
 type MeetupGroup struct {
+	FilePath   string
 	MeetupID   string            `json:"meetupID"`
+	MeetupName string            `json:"meetupName"`
 	Organizers []string          `json:"organizers"`
 	Meetups    map[string]Meetup `json:"meetups"`
 }

--- a/jakarta/cloud-native/README.md
+++ b/jakarta/cloud-native/README.md
@@ -1,9 +1,7 @@
-# Cloud Native Jakarta Meetup
-	
-	## Organizers
-	- imrenagi
-	- prakashdivy
-	- armandcaesario
-	- indrajatiwidyatmoko
-	
-	
+# Meetups organized by Cloud Native Jakarta
+
+## Organizers
+- imrenagi
+- prakashdivy
+- armandcaesario
+- indrajatiwidyatmoko

--- a/jakarta/cloud-native/README.md
+++ b/jakarta/cloud-native/README.md
@@ -1,14 +1,9 @@
-# Meetups organized by Cloud Native Jakarta
-
-<img width="50%" align="right" alt="Meetup Group Logo" src="">
-
-## Description
-
-<p>Cloud Native Jakarta is a meet-up group focusing on microservice with Cloud Native stack.</p>
-
-## Organizers
-
-- Imre Nagi [@imrenagi](https://github.com/imrenagi)
-- Prakash Divy [@prakashdivyy](https://github.com/prakashdivyy)
-- Armand Caesario [@mandocaesar](https://github.com/mandocaesar)
-- Indrajati Widyatmoko [@indramoko](https://github.com/indramoko)
+# Cloud Native Jakarta Meetup
+	
+	## Organizers
+	- imrenagi
+	- prakashdivy
+	- armandcaesario
+	- indrajatiwidyatmoko
+	
+	

--- a/jakarta/cloud-native/meetup.yaml
+++ b/jakarta/cloud-native/meetup.yaml
@@ -1,5 +1,10 @@
 meetupID: Cloud-Native-Jakarta
 meetupName: Cloud Native Jakarta
+organizers:
+- imrenagi
+- prakashdivy
+- armandcaesario
+- indrajatiwidyatmoko
 meetups:
   "20190429":
     presentations:
@@ -143,8 +148,3 @@ meetups:
     sponsors:
     - company: airy
       role: Venue           
-organizers:
-- imrenagi
-- prakashdivy
-- armandcaesario
-- indrajatiwidyatmoko

--- a/jakarta/cloud-native/meetup.yaml
+++ b/jakarta/cloud-native/meetup.yaml
@@ -1,4 +1,5 @@
 meetupID: Cloud-Native-Jakarta
+meetupName: Cloud Native Jakarta
 meetups:
   "20190429":
     presentations:

--- a/jakarta/cloud-native/meetup.yaml
+++ b/jakarta/cloud-native/meetup.yaml
@@ -1,5 +1,3 @@
-latitude: -6.2295712
-longitude: 106.7594779
 meetupID: Cloud-Native-Jakarta
 meetups:
   "20190429":
@@ -10,13 +8,13 @@ meetups:
       - imrenagi
       title: Welcoming speech and opening
     - duration: 35m0s
-      recordings: https://www.youtube.com/watch?v=D6WJcjVPDbI
+      recording: https://www.youtube.com/watch?v=D6WJcjVPDbI
       slides: https://slides.com/armandcaesario/microservicebasic#/
       speakers:
       - armandcaesario
       title: Introduction to Microservice
     - duration: 35m0s
-      recordings: https://www.youtube.com/watch?v=FeWwev0OBFA
+      recording: https://www.youtube.com/watch?v=FeWwev0OBFA
       slides: https://www.slideshare.net/PrakashDivy/introduction-to-grpc
       speakers:
       - prakashdivy
@@ -37,13 +35,13 @@ meetups:
       - armandcaesario
       title: Welcoming speech and opening
     - duration: 35m0s
-      recordings: https://www.youtube.com/watch?v=fszTBvZEZ_4
+      recording: https://www.youtube.com/watch?v=fszTBvZEZ_4
       slides: null
       speakers:
       - welly.tambunan
       title: Messaging Patterns
     - duration: 35m0s
-      recordings: https://www.youtube.com/watch?v=w2J2S6v3K50
+      recording: https://www.youtube.com/watch?v=w2J2S6v3K50
       slides: https://docs.google.com/presentation/d/1FtU8F2mDxe-U4cUBUHrpJmx6FTafUv0FETF1qcxobv4/edit?usp=sharing
       speakers:
       - prakashdivy
@@ -65,13 +63,13 @@ meetups:
       - prakashdivy
       title: Welcoming speech and opening
     - duration: 35m0s
-      recordings: https://www.youtube.com/watch?v=FGQVGSJPjH0&t=25s
+      recording: https://www.youtube.com/watch?v=FGQVGSJPjH0&t=25s
       slides: null
       speakers:
       - resi.respati
       title: 'Microfrontends: extending microservices to the frontend'
     - duration: 35m0s
-      recordings: ""
+      recording: ""
       slides: ""
       speakers:
       - zulfa.achsani
@@ -92,19 +90,19 @@ meetups:
       - imrenagi
       title: Welcoming speech and opening
     - duration: 35m0s
-      recordings: ""
+      recording: ""
       slides: ""
       speakers:
       - kennard.wicoady
       title: 'Domain Driven Design: Preparing for Microservices Architecture'
     - duration: 35m0s
-      recordings: ""
+      recording: ""
       slides: ""
       speakers:
       - martono.wibowo
       title:  Lifecycle and Scalabilty Microservice with Kubernetes
     - duration: 35m0s
-      recordings: ""
+      recording: ""
       slides: ""
       speakers:
       - donnie.prakoso
@@ -125,13 +123,13 @@ meetups:
       - imrenagi
       title: Welcoming speech and opening
     - duration: 35m0s
-      recordings: ""
+      recording: ""
       slides: ""
       speakers:
       - dio
       title: 'Envoy and Contributing to Open Source'
     - duration: 35m0s
-      recordings: ""
+      recording: ""
       slides: ""
       speakers:
       - evan.adiprasetyo

--- a/jakarta/kubernetes/README.md
+++ b/jakarta/kubernetes/README.md
@@ -1,5 +1,7 @@
-# Jakarta Kubernetes Meetup
-	
-	## Organizers
-	
-	
+# Meetups organized by Jakarta Kubernetes
+
+## Organizers
+- girikuncoro
+- irvifa
+- imrenagi
+- iqbalfarabi

--- a/jakarta/kubernetes/README.md
+++ b/jakarta/kubernetes/README.md
@@ -1,3 +1,5 @@
 # Jakarta Kubernetes Meetup
-
-TODO(giri): Generated from `meetup.yaml`
+	
+	## Organizers
+	
+	

--- a/jakarta/kubernetes/meetup.yaml
+++ b/jakarta/kubernetes/meetup.yaml
@@ -1,5 +1,10 @@
 meetupID: Jakarta-Kubernetes
 meetupName: Jakarta Kubernetes
+organizers:
+- girikuncoro
+- irvifa
+- imrenagi
+- iqbalfarabi
 meetups:
   "20180110":
     presentations:

--- a/jakarta/kubernetes/meetup.yaml
+++ b/jakarta/kubernetes/meetup.yaml
@@ -1,4 +1,5 @@
 meetupID: Jakarta-Kubernetes
+meetupName: Jakarta Kubernetes
 meetups:
   "20180110":
     presentations:

--- a/jakarta/kubernetes/meetup.yaml
+++ b/jakarta/kubernetes/meetup.yaml
@@ -18,7 +18,7 @@ meetups:
       - girikuncoro
       title: Kubernetes upstream community update
     - duration: 30m0s
-      recordings: https://www.youtube.com/watch?v=DZQOgIWN1pE
+      recording: https://www.youtube.com/watch?v=DZQOgIWN1pE
       slides: https://bit.ly/knative
       speakers:
       - pahleviauliya


### PR DESCRIPTION
This is reduced scope of meetup generator tool, that can load speaker, company, and meetup event info, then update README.md for each meetup group. Addressed part of #13

The README.md files were generated using `./bin/generator`

To try this out locally, run:
```
make bin-generator
./bin/generator
```