### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/create-meetup-event.md
+++ b/.github/ISSUE_TEMPLATE/create-meetup-event.md
@@ -53,7 +53,7 @@ Update the checklist accordingly and add comment on meetup.com event page link.
 
 ### 3 days after the event
 - [ ] Get slides from speakers
-- [ ] Upload slides from speakers to Github (refer to TODO)
+- [ ] Upload slides (in the form of PDF so that it will be persisted) from speakers to Github (refer to TODO). You can do it in the "slides" folder in your city's folder. 
 - [ ] Upload selected pictures to meetup.com page
 - [ ] Upload pictures to community drive or Google photos (refer to TODO)
 - [ ] Optional: { if recorded } Upload videos to Youtube (refer to TODO)


### PR DESCRIPTION
Remind organizers to convert the slides both from speakers and community's slides to PDF so that it can be persisted and won't be lost if the link is broken. 
Organizers can upload it in the "slides" folder in each of their city's meetup group folder, and then put the link at the city's yaml file to be generated for the README. 